### PR TITLE
Setting wiremock mapping from dir should fail in case dir doesn't exist

### DIFF
--- a/docker_test_tools/wiremock.py
+++ b/docker_test_tools/wiremock.py
@@ -42,6 +42,9 @@ class WiremockController(object):
         :param str dir_path: directory path to scan - should contain json mapping files.
         """
         logging.debug('Setting service %s wiremock mapping using directory %s', self.url, dir_path)
+        if not os.path.isdir(dir_path):
+            raise ValueError("'%s' is not a valid dir" % dir_path)
+
         mapping_files_pattern = os.path.join(dir_path, '*.json')
         self.set_mapping_from_files(glob.iglob(mapping_files_pattern))
 

--- a/tests/ut/test_wiremock.py
+++ b/tests/ut/test_wiremock.py
@@ -86,11 +86,13 @@ class TestWiremockController(unittest.TestCase):
         for test_path in test_paths:
             from_file_mock.assert_any_call(test_path)
 
+    @mock.patch('os.path.isdir')
     @mock.patch('docker_test_tools.wiremock.WiremockController.set_mapping_from_files')
-    def test_set_mapping_from_dir(self, from_files_mock):
+    def test_set_mapping_from_dir(self, from_files_mock, is_dir_mock):
         """Test 'set_mapping_from_dir' method."""
         test_paths = ['json-file-path-1', 'json-file-path-2']
         test_dir = 'some/dir'
+        is_dir_mock.return_value = True
 
         with mock.patch('glob.iglob') as glob_mock:
             glob_mock.return_value = test_paths
@@ -144,3 +146,11 @@ class TestWiremockController(unittest.TestCase):
         with mock.patch("requests.delete", mock_delete):
             self.controller.delete_request_journal()
             mock_delete.assert_called_once_with("http://mocked.service:9999/__admin/requests")
+
+    def test_set_mapping_from_non_existing_dir(self):
+        """Test 'set_mapping_from_non_existing_dir' method."""
+        test_paths = ['json-file-path-1', 'json-file-path-2']
+        test_dir = 'some/dir'
+
+        with self.assertRaises(ValueError):
+            self.controller.set_mapping_from_dir(test_dir)


### PR DESCRIPTION
This solves #14.
+ UT