### PR TITLE
is_container_ready should return False if container was not found

### DIFF
--- a/docker_test_tools/environment.py
+++ b/docker_test_tools/environment.py
@@ -229,7 +229,10 @@ class EnvironmentController(object):
 
         :param str name: container name as it appears in the docker compose file.
         """
-        status_output = self.inspect_container(name)['State']
+        try:
+            status_output = self.inspect_container(name)['State']
+        except RuntimeError:
+            return False
 
         if 'Health' in status_output:
             is_ready = status_output['Health']['Status'] == "healthy"


### PR DESCRIPTION
Currently it raises an exception and as a result wait_for_services fails
immediately if it runs before the containers are running